### PR TITLE
ci(main.yml, requirements-dev.txt): add reference to req file in req-dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,7 +19,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Pytest
       run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
-black==20.8b1
+-r requirements.txt
+black==20.8b-1
 codecov==2.1.11
 django-stubs==1.7.0
 isort==5.7.0


### PR DESCRIPTION
The requirements for the project are split between `requirements.txt` and `requirements-dev.txt`. This meant that one had to call `pip install -r <filename>` twice in the github action. However, `pip` provides an easier way to split dependencies between files like [so](https://stackoverflow.com/a/11704396/11667450). This commit makes that change.