### PR TITLE
build(.gitignore): add python virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ target/
 
 # mypy
 .mypy_cache/
+
+# python virtual environments
+.venv
+venv
+.env


### PR DESCRIPTION
I added common virtual environment folders to gitignore file to ensure that no one commits their virtual env to the remote repository.