### PR TITLE
ci: support testing for django vers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-    - name: Pytest
-      run: |
-        pytest --cov=ariadne_django --cov=tests
+    - name: Run tests
+      run: tox
     - uses: codecov/codecov-action@v1
     - name: Linters
       if: ${{ matrix.python-version != 3.6 }}

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,4 @@ lines_after_imports=2
 line_length=120
 multi_line_output=3
 sections=FUTURE,STDLIB,DJANGO,ARIADNE,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-skip=__init__.py,migrations
+skip=__init__.py,migrations,.tox,.venv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ python-multipart==0.0.5
 pytz==2019.3
 snapshottest==0.6.0
 typing-extensions==3.7.4.3
+tox==3.23.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist =
+    django32-py{39,38,37,36}
+    django31-py{39,38,37,36}
+    django30-py{39,38,37,36}
+skip_missing_interpreters = true
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
+[testenv]
+deps =
+    django32: {[django]3.2}
+    django31: {[django]3.1}
+    django30: {[django]3.0}
+commands =
+    pip install -r requirements.txt
+    pip install -r requirements-dev.txt
+    pip show django -v
+    pytest --cov=ariadne_django --cov=tests
+
+[django]
+3.2 = Django>="3.2.0"
+3.1 = Django>="3.1.0,<3.2.0"
+3.0 = Django>="3.0.0,<3.1.0"


### PR DESCRIPTION
Fixes #29 

With this new configuration, we are able
to test against django 3.0, 3.1, 3.2.

This is a combination of 4 commits.

ci(tox.ini): add tox configuration

build(requirements-dev.txt): add tox to dev deps

ci(main.yml): automate tests with github actions

build(.isort.cfg): add virtual env and tox to skip