### PR TITLE
Add sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+
+# this will help us include docstrings from the py files themselves further
+# down the line, if we decide to
+sys.path.insert(0, os.path.abspath(".."))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "ariadne_django"
+copyright = "2021, Diptesh Choudhuri"
+author = "Diptesh Choudhuri"
+
+# The full version, including alpha/beta/rc tags
+release = "0.2.0"
+
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx_rtd_theme",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,16 @@
+Welcome to ariadne_django's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   installing.rst
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -1,0 +1,25 @@
+#########################
+Installing ariadne_django
+#########################
+
+You must have :code:`python` and :code:`pip` installed on your system, and in your :code:`PATH`.
+An activated virtual environment is also recommended.
+
+Using :code:`pip`:
+==================
+
+.. code-block:: bash
+
+    pip install ariadne_django
+
+Using :code:`poetry`:
+=====================
+
+`Poetry <https://python-poetry.org/>`_ is a tool for dependency management and packaging in Python. It allows
+you to declare the libraries your project depends on and it will manage
+(install/update) them for you.
+
+
+.. code-block:: bash
+
+    poetry add ariadne_django

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -5,15 +5,18 @@ Installing ariadne_django
 You must have :code:`python` and :code:`pip` installed on your system, and in your :code:`PATH`.
 An activated virtual environment is also recommended.
 
+Getting ariadne_django
+======================
+
 Using :code:`pip`:
-==================
+------------------
 
 .. code-block:: bash
 
     pip install ariadne_django
 
 Using :code:`poetry`:
-=====================
+---------------------
 
 `Poetry <https://python-poetry.org/>`_ is a tool for dependency management and packaging in Python. It allows
 you to declare the libraries your project depends on and it will manage
@@ -23,3 +26,32 @@ you to declare the libraries your project depends on and it will manage
 .. code-block:: bash
 
     poetry add ariadne_django
+
+Add to settings
+===============
+
+Add :code:`ariadne_django` to your project's :code:`INSTALLED_APPS` setting (usually
+located in :code:`<project_name>/settings.py`):
+
+.. code-block:: python
+
+    INSTALLED_APPS = [
+        # other stuff
+        "ariadne_django",
+    ]
+
+
+The Ariadne app provides a Django template for GraphQL Playground. Make sure that your
+django project is configured to load templates from application directories. This can be
+done by checking if :code:`APP_DIRS` option located in :code:`TEMPLATES` setting is set to
+:code:`True`:
+
+.. code-block:: python
+
+    TEMPLATES = [
+        {
+            # ...,
+            'APP_DIRS': True,
+            # ...
+        },
+    ]

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,7 @@ pytz==2019.3
 snapshottest==0.6.0
 typing-extensions==3.7.4.3
 tox==3.23.1
+sphinx==4.0.2
+sphinx_rtd_theme==0.5.2
+rstcheck==3.3.1
+sphinx_autobuild==2021.3.14


### PR DESCRIPTION
Resolves #12

This is still a WIP.

@maxmorlocke It would be great if you configure the readthedocs settings and deploy the documentation. Meanwhile, I will try to write the documentation down.

**TODO**: Add github action to automatically deploy documentation to readthedocs.