### PR TITLE
rename scalar from JSONBlob to JSON to match docs

### DIFF
--- a/ariadne_django/scalars/json.py
+++ b/ariadne_django/scalars/json.py
@@ -5,7 +5,7 @@ from ariadne import ScalarType
 import simplejson as json  # supports decimals, etc.
 
 
-json_scalar = ScalarType("JSONBlob")
+json_scalar = ScalarType("JSON")
 
 
 @json_scalar.serializer


### PR DESCRIPTION
Per the scalar readme the json scalar be `JSON` and not `JSONBlob`.

This would be a breaking change from the published package. Dunno how we want to deal with that (support both but with a deprecation warning?)

Alternatively, we could add `JSON` and still keep `JSONBlob`, but have it serialize to `bytes` and not a `str`