### PR TITLE
Use `json` instead of `simplejson`

### DIFF
--- a/ariadne_django/scalars/json.py
+++ b/ariadne_django/scalars/json.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from ariadne import ScalarType
 
-import simplejson as json  # supports decimals, etc.
+import json
 
 
 json_scalar = ScalarType("JSON")

--- a/ariadne_django/scalars/json.py
+++ b/ariadne_django/scalars/json.py
@@ -1,8 +1,7 @@
+import json
 from typing import Any
 
 from ariadne import ScalarType
-
-import json
 
 
 json_scalar = ScalarType("JSON")

--- a/ariadne_django/tests/graphql_query_test.py
+++ b/ariadne_django/tests/graphql_query_test.py
@@ -3,7 +3,7 @@ from typing import IO, Any, Dict, List, Optional, Tuple
 from django.http import HttpResponse
 from django.test import Client, TestCase
 
-import simplejson as json
+import json
 
 
 class BaseGraphQLQueryTest(TestCase):

--- a/ariadne_django/tests/graphql_query_test.py
+++ b/ariadne_django/tests/graphql_query_test.py
@@ -1,9 +1,8 @@
+import json
 from typing import IO, Any, Dict, List, Optional, Tuple
 
 from django.http import HttpResponse
 from django.test import Client, TestCase
-
-import json
 
 
 class BaseGraphQLQueryTest(TestCase):

--- a/ariadne_django/views/base.py
+++ b/ariadne_django/views/base.py
@@ -26,10 +26,10 @@ DEFAULT_PLAYGROUND_OPTIONS = {
     "settings": {
         "request.credentials": "same-origin",
     },
-
     # Request HTTP headers added by default
     "headers": {},
 }
+
 
 class BaseGraphQLView(TemplateResponseMixin, ContextMixin, View):
     http_method_names = ["get", "post", "options"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ariadne>=0.13.0,<0.13.99
 django>=2.2
 python-dateutil==2.8.1
-simplejson==3.17.2

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -1,11 +1,11 @@
 # pylint: disable=comparison-with-callable,protected-access
 import uuid
 from decimal import Decimal, InvalidOperation
+from json import JSONDecodeError
 
 from django.utils import timezone
 
 import pytest
-from json import JSONDecodeError
 
 from ariadne_django.scalars import (
     date_scalar,
@@ -27,7 +27,7 @@ from ariadne_django.scalars import (
     time_scalar,
     uuid_scalar,
 )
-from ariadne_django.scalars.timedelta import serialize_timedelta, parse_timedelta_value, timedelta_scalar
+from ariadne_django.scalars.timedelta import parse_timedelta_value, serialize_timedelta, timedelta_scalar
 
 
 @pytest.fixture

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from django.utils import timezone
 
 import pytest
-from simplejson import JSONDecodeError
+from json import JSONDecodeError
 
 from ariadne_django.scalars import (
     date_scalar,


### PR DESCRIPTION
Closes #43 

## What I did

Replaced `simplejson` with `json`, which is part of Python's standard library since version 2.6.

## How to test

Run all tests, they should pass! No noticeable changes should be expected with these changes.