### PR TITLE
Fix linting issues

### DIFF
--- a/ariadne_django/views/base.py
+++ b/ariadne_django/views/base.py
@@ -26,10 +26,10 @@ DEFAULT_PLAYGROUND_OPTIONS = {
     "settings": {
         "request.credentials": "same-origin",
     },
-
     # Request HTTP headers added by default
     "headers": {},
 }
+
 
 class BaseGraphQLView(TemplateResponseMixin, ContextMixin, View):
     http_method_names = ["get", "post", "options"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-black==20.8b-1
+black==21.10b0
 codecov==2.1.11
 django-stubs==1.7.0
 isort==5.7.0
@@ -13,5 +13,5 @@ pytest-mock==3.5.1
 python-multipart==0.0.5
 pytz==2019.3
 snapshottest==0.6.0
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.2
 tox==3.23.1

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -27,7 +27,7 @@ from ariadne_django.scalars import (
     time_scalar,
     uuid_scalar,
 )
-from ariadne_django.scalars.timedelta import serialize_timedelta, parse_timedelta_value, timedelta_scalar
+from ariadne_django.scalars.timedelta import parse_timedelta_value, serialize_timedelta, timedelta_scalar
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR stems from [this comment](https://github.com/reset-button/ariadne_django/pull/44#issuecomment-982239878)

## What I did

Right now, there are a couple linting problems on `main`. This PR fixes these changes by running `black` and `isort`, and commiting the changes.

Also, right now checks are failing for Python 3.9 due to an incompatibility with the `black` version that's set in `requirements-dev.txt`. This PR also updates black to avoid this problem.

## How to test

All linting checks should pass, both locally and in CI:

```bash
pylint ariadne_django tests setup.py
mypy ariadne_django --ignore-missing-imports
black -l 120 --check . 
isort -c .
```