### PR TITLE
Compatibility fix for Django Debug Toolbar

### DIFF
--- a/ariadne_django/templates/ariadne_django/graphql_playground.html
+++ b/ariadne_django/templates/ariadne_django/graphql_playground.html
@@ -553,7 +553,7 @@
     </div>
   </div>
 
-  <div id="root" />
+  <div id="root"></div>
   <script type="text/javascript">
     window.addEventListener('load', function (event) {
 


### PR DESCRIPTION
Without this change, Django Debug Toolbar won't show on the playground page.

Note that by default only the GET request that loaded the page is shown, but GraphQL queries can be inspected by looking at the History panel (eg look at the most recent POST request)

https://django-debug-toolbar.readthedocs.io/en/latest/panels.html#debug_toolbar.panels.history.HistoryPanel

Resolves #61