### PR TITLE
Add execution context class to graphql kwargs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 black==22.6.0
-codecov==2.1.11
+codecov>=2.1.11
 django-stubs==1.7.0
 isort==5.7.0
 mypy==0.812

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ariadne>=0.13.0
+ariadne>=0.18.0
 django>=2.2
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "django>=2.2.0",
-        "ariadne>=0.13.0",
+        "ariadne>=0.18.0",
     ],
     classifiers=CLASSIFIERS,
     platforms=["any"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from django.test import RequestFactory
 from ariadne import MutationType, QueryType, SubscriptionType, make_executable_schema, upload_scalar
 
 import pytest
-from graphql import ValidationRule
+from graphql import ExecutionContext, ValidationRule
 
 
 def pytest_configure():
@@ -190,3 +190,11 @@ def validation_rule():
         pass
 
     return NoopRule
+
+
+@pytest.fixture
+def execution_context_class():
+    class CustomExecutionContext(ExecutionContext):
+        pass
+
+    return CustomExecutionContext

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,8 +3,12 @@ from unittest.mock import ANY, Mock
 
 from django.test import override_settings
 
-from ariadne.types import ExtensionSync
-
+try:
+    from ariadne.types import ExtensionSync
+except ImportError:
+    # From ariadne 0.20 Extension supports both sync and async contexts
+    # https://github.com/mirumee/ariadne/blob/main/CHANGELOG.md#020-2023-06-21
+    from ariadne.types import Extension as ExtensionSync
 import pytest
 
 from ariadne_django.views import GraphQLView
@@ -81,7 +85,7 @@ def test_custom_root_value_function_is_called_with_context_value(request_factory
         context_value={"test": "TEST-CONTEXT"},
         root_value=get_root_value,
     )
-    get_root_value.assert_called_once_with({"test": "TEST-CONTEXT"}, ANY)
+    get_root_value.assert_called_once_with({"test": "TEST-CONTEXT"}, ANY, ANY, ANY)
 
 
 def test_custom_validation_rule_is_called_by_query_validation(mocker, request_factory, schema, validation_rule):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,7 +1,10 @@
 import json
-from unittest.mock import ANY, Mock
+from typing import List
+from unittest.mock import ANY, Mock, call
 
 from django.test import override_settings
+from graphql.language import FieldNode
+from graphql.pyutils import Path
 
 try:
     from ariadne.types import ExtensionSync
@@ -9,6 +12,7 @@ except ImportError:
     # From ariadne 0.20 Extension supports both sync and async contexts
     # https://github.com/mirumee/ariadne/blob/main/CHANGELOG.md#020-2023-06-21
     from ariadne.types import Extension as ExtensionSync
+from graphql import ExecutionContext, GraphQLBoolean, GraphQLResolveInfo, GraphQLScalarType
 import pytest
 
 from ariadne_django.views import GraphQLView
@@ -58,6 +62,18 @@ def test_custom_context_value_function_result_is_passed_to_resolvers(request_fac
         context_value=get_context_value,
     )
     assert data == {"data": {"testContext": "TEST-CONTEXT"}}
+
+
+def test_custom_execution_context_is_used_to_execute_operation(mocker, request_factory, schema, execution_context_class):
+    spy_execution_context_execute_operation = mocker.spy(execution_context_class, 'execute_operation')
+
+    execute_query(
+        request_factory,
+        schema,
+        {"query": "{ status }"},
+        execution_context_class=execution_context_class,
+    )
+    spy_execution_context_execute_operation.assert_called_once()
 
 
 def test_custom_root_value_is_passed_to_resolvers(request_factory, schema):


### PR DESCRIPTION
Since ariadne 0.18 it is possible to change the execution context class. This makes it possible to use an execution context that supports deferred execution of dataloaders: https://github.com/jkimbo/graphql-sync-dataloaders

As ariadne-django has not been updated to ariadne 0.18 yet, it does not pass the `execution_context_class` parameter to ariadne. I made some changes to add this to the list of arguments in get_kwargs_graphql.

Since this would require at least ariadne 0.18, I increased the version of the dependency. I also made some small changes that were neccessary to get the tests to run with API changes in newer versions of ariande